### PR TITLE
Refactor and fix CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,14 +17,17 @@ jobs:
   # This job's steps must be synced with prePublishCheck Gradle task's checks to ensure that
   # we check required stuff on CI and at the same time developers can run the Gradle task to verify
   # their changes before publishing.
-  preflight_check:
+  preflight_checks:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
         uses: actions/checkout@v4
 
-      - uses: ./.github/actions/setup
-      - uses: ./.github/actions/basic-preflight-check
+      - name: Setup
+        uses: ./.github/actions/setup
+        
+      - name: Basic preflight checks
+        uses: ./.github/actions/basic-preflight-check
 
       - name: Verify publishing
         run: ./gradlew verifyPublishing
@@ -45,7 +48,7 @@ jobs:
           ./gradlew :app:testDebugUnitTest
 
   publish:
-    needs: preflight_check
+    needs: preflight_checks
     runs-on: ubuntu-latest
     permissions:
       # Needed by softprops/action-gh-release to be able to create a release
@@ -54,7 +57,8 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
 
-      - uses: ./.github/actions/setup
+      - name: Setup
+        uses: ./.github/actions/setup
 
       - name: Publish to Maven Central
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,6 +24,9 @@ jobs:
       # action needs to be first checked out by the checkout action.
       - name: Check out code
         uses: actions/checkout@v5
+        with:
+          # Fetch all history including all tags, because we need previous release tag for verifyPublishing task
+          fetch-depth: 0
 
       - name: Setup
         uses: ./.github/actions/setup

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,8 @@ jobs:
   preflight_checks:
     runs-on: ubuntu-latest
     steps:
+      # actions/checkout can't be included in the composite setup action, because the composite
+      # action needs to be first checked out by the checkout action.
       - name: Check out code
         uses: actions/checkout@v5
 
@@ -54,6 +56,8 @@ jobs:
       # Needed by softprops/action-gh-release to be able to create a release
       contents: write
     steps:
+      # actions/checkout can't be included in the composite setup action, because the composite
+      # action needs to be first checked out by the checkout action.
       - name: Check out code
         uses: actions/checkout@v5
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup
         uses: ./.github/actions/setup
@@ -55,7 +55,7 @@ jobs:
       contents: write
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup
         uses: ./.github/actions/setup

--- a/.github/workflows/main_branch.yml
+++ b/.github/workflows/main_branch.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup
         uses: ./.github/actions/setup

--- a/.github/workflows/main_branch.yml
+++ b/.github/workflows/main_branch.yml
@@ -9,6 +9,8 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
+      # actions/checkout can't be included in the composite setup action, because the composite
+      # action needs to be first checked out by the checkout action.
       - name: Check out code
         uses: actions/checkout@v5
 

--- a/.github/workflows/main_branch.yml
+++ b/.github/workflows/main_branch.yml
@@ -12,5 +12,8 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
 
-      - uses: ./.github/actions/setup
-      - uses: ./.github/actions/basic-preflight-check
+      - name: Setup
+        uses: ./.github/actions/setup
+
+      - name: Preflight checks
+        uses: ./.github/actions/basic-preflight-check

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -13,5 +13,8 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
 
-      - uses: ./.github/actions/setup
-      - uses: ./.github/actions/basic-preflight-check
+      - name: Setup
+        uses: ./.github/actions/setup
+
+      - name: Preflight checks
+        uses: ./.github/actions/basic-preflight-check

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -10,6 +10,8 @@ jobs:
   pull_request:
     runs-on: ubuntu-latest
     steps:
+      # actions/checkout can't be included in the composite setup action, because the composite
+      # action needs to be first checked out by the checkout action.
       - name: Check out code
         uses: actions/checkout@v5
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup
         uses: ./.github/actions/setup


### PR DESCRIPTION
Fixes incorrectly working verifyPublishing task because only one commit of current branch was checked out and it needs also release tags.